### PR TITLE
fix: the front-end file embedding skipped files that start with a dot…

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -33,7 +33,7 @@ type DashboardCliParam struct {
 
 var (
 	dashboardCliParam DashboardCliParam
-	//go:embed *-dist
+	//go:embed all:*-dist
 	frontendDist embed.FS
 )
 


### PR DESCRIPTION
Add `all:` to embed all front-end files